### PR TITLE
Added targets.*.toolchainOf

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ As a flake (recommended)
     # fenix.packages.x86_64-linux.toolchainOf { channel = "stable"; date = "2021-06-17"; sha256 = ""; }
     # fenix.packages.x86_64-linux.targets.aarch64-unknown-linux-gnu.latest.rust-std
     # fenix.packages.x86_64-linux.targets.wasm32-unknown-unknown.stable.rust-std
+    # fenix.packages.x86_64-linux.targets.wasm32-unknown-unknown.toolchainOf { date = "2021-07-07"; sha256 = ""; }
     # fenix.packages.x86_64-linux.rust-analyzer
     # fenix.packages.x86_64-linux.rust-analyzer-vscode-extension
 

--- a/flake.nix
+++ b/flake.nix
@@ -77,14 +77,14 @@
 
           beta = fromManifestFile' v "rust-beta" ./data/beta.toml;
 
-          targets = let 
+          targets = let
             collectedTargets = zipAttrsWith (_: foldl (x: y: x // y) { }) [
               (mkToolchains "stable")
               (mkToolchains "beta")
               nightlyToolchains
             ];
-          in
-            mapAttrs (target: v: v // { toolchainOf = toolchainOf' target; }) collectedTargets;
+          in mapAttrs (target: v: v // { toolchainOf = toolchainOf' target; })
+          collectedTargets;
 
           rust-analyzer = (pkgs.makeRustPlatform {
             inherit (nightlyToolchains.${v}.minimal) cargo rustc;

--- a/flake.nix
+++ b/flake.nix
@@ -77,11 +77,14 @@
 
           beta = fromManifestFile' v "rust-beta" ./data/beta.toml;
 
-          targets = zipAttrsWith (_: foldl (x: y: x // y) { }) [
-            (mkToolchains "stable")
-            (mkToolchains "beta")
-            nightlyToolchains
-          ];
+          targets = let 
+            collectedTargets = zipAttrsWith (_: foldl (x: y: x // y) { }) [
+              (mkToolchains "stable")
+              (mkToolchains "beta")
+              nightlyToolchains
+            ];
+          in
+            mapAttrs (target: v: v // { toolchainOf = toolchainOf' target; }) collectedTargets;
 
           rust-analyzer = (pkgs.makeRustPlatform {
             inherit (nightlyToolchains.${v}.minimal) cargo rustc;


### PR DESCRIPTION
This allows to specify date and channel of different cross toolchains.

E.g:
```nix
targets.wasm32-unknown-unknown.toolchainOf { date = "2021-07-07"; sha256 = ""; }
```