### PR TITLE
Set correct rpath for `lib/rustlib/*/bin` binaries

### DIFF
--- a/lib/mk-toolchain.nix
+++ b/lib/mk-toolchain.nix
@@ -47,7 +47,7 @@ let
                 if isELF "$file"; then
                   patchelf \
                     --set-interpreter ${stdenv.cc.bintools.dynamicLinker} \
-                    --set-rpath $out/lib \
+                    --set-rpath ${stdenv.cc.cc.lib}/lib:${rpath} \
                     "$file" || true
                 fi
               done


### PR DESCRIPTION
Closes #67 

Fix the rpath used for `lib/rustlib/*/bin` binaries, since `rust-ldd` has a dependency on `zlib.so` and `libstdc++.so.6`