### PR TITLE
Update rust-analyzer GitHub repository lookup

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -28,7 +28,7 @@ jobs:
           nix-shell --run ./update -p "python3.withPackages (ps: [ ps.toml ])"
           nix flake update
           curl -fLSso data/rust-analyzer-vsix.zip \
-            https://github.com/rust-analyzer/rust-analyzer/releases/download/nightly/rust-analyzer.vsix || true
+            https://github.com/rust-lang/rust-analyzer/releases/download/nightly/rust-analyzer-no-server.vsix || true
 
           git commit -am "update: rust toolchains, rust analyzer, flake.lock"
           git push

--- a/flake.nix
+++ b/flake.nix
@@ -4,7 +4,7 @@
   inputs = {
     nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
     rust-analyzer-src = {
-      url = "github:rust-analyzer/rust-analyzer/nightly";
+      url = "github:rust-lang/rust-analyzer/nightly";
       flake = false;
     };
   };


### PR DESCRIPTION
The repo has been moved into the official Rust GitHub org.

Also corrected the VS Code plugin download, path has changed in the release artifacts, hence why it hasn't been updated in 4 months.