### PR TITLE
Fix RUST_SRC_PATH comment

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ Some outputs are toolchains, a rust toolchain in fenix is structured like this:
   rustc = <derivation>; # rustc with rust-std
   rustc-unwrapped = <derivation>; # rustc without rust-std, same as rustc.unwrapped
   rustfmt = <derivation>; # alias to rustfmt-preview
-  rust-src = <derivation>; # RUST_SRC_PATH = "${fenix.complete.rust-src}/bin/rust-lib/src"
+  rust-src = <derivation>; # RUST_SRC_PATH = "${fenix.complete.rust-src}/lib/rustlib/src/rust/library"
   # ...
 
   # derivation with all the components


### PR DESCRIPTION
Evidence for change:
```
➜ ls /nix/store/zwk4hlhxr9pby4n3jfh856imyvj3zk1v-rust-src-stable-2022-05-19/bin/rust-lib/src
lsd: /nix/store/zwk4hlhxr9pby4n3jfh856imyvj3zk1v-rust-src-stable-2022-05-19/bin/rust-lib/src: No such file or directory (os error 2).
```

Digging a bit a ended up here:

```
➜ ls /nix/store/zwk4hlhxr9pby4n3jfh856imyvj3zk1v-rust-src-stable-2022-05-19/lib/rustlib/src/rust/library
 alloc       core          panic_unwind    proc_macro          rtstartup                   rustc-std-workspace-core   std       test
 backtrace   panic_abort   portable-simd   profiler_builtins   rustc-std-workspace-alloc   rustc-std-workspace-std    stdarch   unwind
```

Which is what prompt this pr with an updated path.