### PR TITLE
[RFC] make fenix work with `nix flake check`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,10 @@ jobs:
           name: nix-community
           signingKey: ${{ secrets.CACHIX_SIGNING_KEY }}
 
+      - name: Check with nix
+        run: |
+          nix flake check
+
       - name: Build with nix
         run: |
           nix build ${{ matrix.build-flags }} .#{{stable,beta,minimal,default,complete}.toolchain,rust-analyzer{,-vscode-extension}}

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ To fix this, use the packages directly or use the following workaround (see [#79
 ```nix
 {
   nixpkgs.overlays = [
-    (_: super: let pkgs = fenix.inputs.nixpkgs.legacyPackages.${super.system}; in fenix.overlay pkgs pkgs)
+    (_: super: let pkgs = fenix.inputs.nixpkgs.legacyPackages.${super.system}; in fenix.overlays.default pkgs pkgs)
   ];
 }
 ```
@@ -47,7 +47,7 @@ To fix this, use the packages directly or use the following workaround (see [#79
         system = "x86_64-linux";
         modules = [
           ({ pkgs, ... }: {
-            nixpkgs.overlays = [ fenix.overlay ];
+            nixpkgs.overlays = [ fenix.overlays.default ];
             environment.systemPackages = with pkgs; [
               (fenix.complete.withComponents [
                 "cargo"

--- a/flake.nix
+++ b/flake.nix
@@ -9,21 +9,42 @@
     };
   };
 
-  outputs = { self, nixpkgs, rust-analyzer-src }: {
-    packages = nixpkgs.lib.genAttrs
-      [
-        "aarch64-darwin"
-        "aarch64-linux"
-        "i686-linux"
-        "x86_64-darwin"
-        "x86_64-linux"
-      ]
-      (system: import ./. {
-        inherit system rust-analyzer-src;
-        inherit (nixpkgs) lib;
-        pkgs = nixpkgs.legacyPackages.${system};
-      });
+  outputs = { self, nixpkgs, rust-analyzer-src }:
+    let
+      inherit (builtins) isAttrs mapAttrs typeOf;
+      inherit (nixpkgs.lib) genAttrs isDerivation warn;
+    in
 
-    overlay = import ./overlay.nix;
-  };
+    {
+      packages = genAttrs
+        [
+          "aarch64-darwin"
+          "aarch64-linux"
+          "i686-linux"
+          "x86_64-darwin"
+          "x86_64-linux"
+        ]
+        (system: mapAttrs
+          (_: x:
+            if isDerivation x then x
+            else if isAttrs x then x // {
+              type = "derivation";
+              name = "dummy-attrset";
+            } else {
+              type = "derivation";
+              name = "dummy-${typeOf x}";
+              __functor = _: x;
+            })
+          (import ./. {
+            inherit system rust-analyzer-src;
+            inherit (nixpkgs) lib;
+            pkgs = nixpkgs.legacyPackages.${system};
+          }));
+
+      overlay = warn
+        "`fenix.overlay` is deprecated; use 'fenix.overlays.default' instead"
+        self.overlays.default;
+
+      overlays.default = final: prev: import ./overlay.nix final prev;
+    };
 }


### PR DESCRIPTION
fixes #60 

also renames `fenix.overlay` to `fenix.overlays.default` as per https://github.com/NixOS/nix/issues/5532
If I did it correctly, this shouldn't be a breaking change, but there is a drawback that `nix build .#stable` now shows `error: attribute 'packages.x86_64-linux.stable.drvPath' does not exist` which might be confusing to the user

before:
```console
$ nix flake check
error: flake attribute 'packages.x86_64-linux.default' is not a derivation
(use '--show-trace' to show detailed location information)

$ nix flake show
github:nix-community/fenix/0748dc3f419917e3548419e91839ee062e1a88fb
├───overlay: Nixpkgs overlay
└───packages
    ├───aarch64-darwin
error: expected a derivation
```

after:
```console
$ nix flake check
trace: warning: `fenix.overlay` is deprecated; use 'fenix.overlays.default' instead
warning: flake output attribute 'overlay' is deprecated; use 'overlays.default' instead

$ nix flake show
github:nix-community/fenix/7d280610237379462e5f2fce7993b17cff53d730
├───overlay: Nixpkgs overlay
├───overlays
│   └───default: Nixpkgs overlay
└───packages
    ├───aarch64-darwin
    │   ├───beta: package 'dummy-attrset'
    │   ├───combine: package 'dummy-lambda'
    │   ├───complete: package 'dummy-attrset'
    │   ├───default: package 'dummy-attrset'
    │   ├───fromManifest: package 'dummy-lambda'
    │   ├───fromManifestFile: package 'dummy-lambda'
    │   ├───fromToolchainFile: package 'dummy-lambda'
    │   ├───latest: package 'dummy-attrset'
    │   ├───minimal: package 'dummy-attrset'
    │   ├───rust-analyzer: package 'rust-analyzer-nightly-53b6d69'
    │   ├───rust-analyzer-vscode-extension: package 'vscode-extension-rust-analyzer-53b6d69'
    │   ├───stable: package 'dummy-attrset'
    │   ├───targets: package 'dummy-attrset'
    │   └───toolchainOf: package 'dummy-lambda'
    ├───aarch64-linux
    [...]
```