### PR TITLE
ci: use cachix auth token

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
         uses: cachix/cachix-action@v10
         with:
           name: nix-community
-          signingKey: ${{ secrets.CACHIX_SIGNING_KEY }}
+          authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
 
       - name: Build with nix
         run: |


### PR DESCRIPTION
Signing keys are harder to rotate than auth tokens