### PR TITLE
Specify name and publisher when building VS Code extension

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -186,6 +186,8 @@ nightlyToolchains.${v} // rec {
     pkgs.vscode-utils.buildVscodeExtension {
       name = "rust-analyzer-${rust-analyzer-rev}";
       src = ./data/rust-analyzer-vsix.zip;
+      vscodeExtName = "rust-analyzer";
+      vscodeExtPublisher = "The Rust Programming Language";
       vscodeExtUniqueId = "rust-lang.rust-analyzer";
       buildInputs = with pkgs; [ jq moreutils ];
       patchPhase = ''


### PR DESCRIPTION
NixOS/nixpkgs@66a6cd1d5191af8d3ad3dfd7c31f49d930696b68 seems to break (or will break once it lands onto `nixos-unstable`) the Rust Analyzer VS Code extension bundled with Fenix because it introduces the `vscodeExtName` and `vscodeExtPublisher` parameters to `pkgs.vscode-utils.buildVscodeExtension`. This pull request specifies these arguments to match the information in the [Visual Studio Marketplace](https://marketplace.visualstudio.com/items?itemName=rust-lang.rust-analyzer).