### PR TITLE
Backport non-update fixes from main to monthly

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -75,14 +75,14 @@ let
   fromToolchainName = target: name: sha256:
     mapNullable
       (matches:
-        let target' = elemAt matches 4; in
+        let target' = elemAt matches 5; in
         toolchainOf' (if target' == null then target else target') {
           inherit sha256;
           channel = elemAt matches 0;
-          date = elemAt matches 2;
+          date = elemAt matches 3;
         })
       (match
-        "^(stable|beta|nightly|[[:digit:]]+\.[[:digit:]]+\.[[:digit:]]+)(-([[:digit:]]{4}-[[:digit:]]{2}-[[:digit:]]{2}))?(-([-[:alnum:]]+))?\n?$"
+        "^(stable|beta|nightly|[[:digit:]]+\.[[:digit:]]+(\.[[:digit:]]+)?)(-([[:digit:]]{4}-[[:digit:]]{2}-[[:digit:]]{2}))?(-([-[:alnum:]]+))?\n?$"
         name);
 
   fromToolchainFile' = target:

--- a/lib/combine.nix
+++ b/lib/combine.nix
@@ -12,7 +12,7 @@ symlinkJoin {
     for file in $(find $out/bin -xtype f -maxdepth 1); do
       install -m755 $(realpath "$file") $out/bin
 
-      if [[ $file =~ /(rustfmt|miri)$ ]]; then
+      if [[ $file =~ /rustfmt$ ]]; then
         continue
       fi
 

--- a/lib/mk-toolchain.nix
+++ b/lib/mk-toolchain.nix
@@ -133,6 +133,13 @@ let
     };
     clippy-preview-unwrapped = toolchain.clippy-preview;
     clippy-unwrapped = toolchain.clippy-preview;
+  } // optionalAttrs (toolchain ? miri-preview) {
+    miri-preview = combine "clippy${suffix}-with-src-${date}"
+      (with toolchain; [ miri-preview rustc rust-src ]) // {
+      unwrapped = toolchain.miri-preview;
+    };
+    miri-preview-unwrapped = toolchain.miri-preview;
+    miri-unwrapped = toolchain.miri-preview;
   };
 
   toolchain'' = toolchain' // mapAttrs' (k: nameValuePair (removeSuffix "-preview" k)) toolchain';

--- a/lib/mk-toolchain.nix
+++ b/lib/mk-toolchain.nix
@@ -118,7 +118,8 @@ let
     components;
 
   toolchain' = toolchain // {
-    toolchain = combine "rust${suffix}-${date}" (attrValues toolchain);
+    toolchain = combine "rust${suffix}-${date}"
+      (attrValues (removeAttrs toolchain [ "rustc-dev" ]));
   } // optionalAttrs (toolchain ? rustc) {
     rustc = combine "rust${suffix}-with-std-${date}"
       (with toolchain; [ rustc rust-std ]) // {


### PR DESCRIPTION
Cherry-pick 930adedd6087df3c324e380b0b4804cf13323eb2, 94390bb3cccc4fa6d1c83706491bcf64861878cd, 7f65a475c26fbc0a07a64c3649c421931a8fbcee to `monthly`.