### PR TITLE
Expose fromToolchainName

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,7 +194,7 @@ Some outputs are toolchains, a rust toolchain in fenix is structured like this:
 <details>
   <summary><code>fromToolchainFile : attrs -> derivation</code></summary>
 
-  Creates a [toolchain](#toolchain) from a [rust toolchain file](https://rust-lang.github.io/rustup/overrides.html#the-toolchain-file), accepts the following arguments:
+  Creates a package from a [rust toolchain file](https://rust-lang.github.io/rustup/overrides.html#the-toolchain-file), accepts the following arguments:
 
   argument | description
   -|-
@@ -211,6 +211,20 @@ Some outputs are toolchains, a rust toolchain in fenix is structured like this:
 
   ```nix
   fromToolchainFile { dir = ./.; }
+  ```
+</details>
+
+<details>
+  <summary><code>fromToolchainName : string -> <a href="#toolchain">toolchain</a></code></summary>
+
+  Creates a [toolchain](#toolchain) from a toolchain name.
+
+  ```nix
+  fromToolchainName "nightly-2021-08-29"
+  ```
+
+  ```nix
+  fromToolchainName (builtins.readFile ./rust-toolchain)
   ```
 </details>
 

--- a/default.nix
+++ b/default.nix
@@ -72,7 +72,7 @@ let
     else
       pkgs.fetchurl { inherit url sha256; });
 
-  fromToolchainName = target: name: sha256:
+  fromToolchainName' = target: name: sha256:
     mapNullable
       (matches:
         let target' = elemAt matches 5; in
@@ -96,14 +96,14 @@ let
         file
       else
         throw "One and only one of `file` and `dir` should be specified");
-      toolchain = fromToolchainName target text sha256;
+      toolchain = fromToolchainName' target text sha256;
     in
     if toolchain == null then
       let t = (fromTOML text).toolchain; in
       if t ? path then
         throw "fenix doesn't support toolchain.path"
       else
-        let toolchain = fromToolchainName target t.channel sha256; in
+        let toolchain = fromToolchainName' target t.channel sha256; in
         combine' "rust-${t.channel}" (attrVals
           (filter (component: toolchain ? ${component}) (unique
             (toolchain.manifest.profiles.${t.profile or "default"}
@@ -132,6 +132,8 @@ nightlyToolchains.${v} // rec {
   toolchainOf = toolchainOf' v;
 
   fromToolchainFile = fromToolchainFile' v;
+
+  fromToolchainName = fromToolchainName' v;
 
   stable = fromManifest' v "-stable" (importJSON ./data/stable.json);
 


### PR DESCRIPTION
Currently, there's 2 ways to use a `rust-toolchain.toml` file:
1. use `toolchainOf` to use the rustup manifest file for a channel at a given date. However, in `rust-toolchain.toml` files, these 2 inputs are joined in a single string. This means users need to rewrite the regex in `fromToolchainName` even though it's *right there*
2. use `fromToolchainFile` to use the toolchain defined by the `rust-toolchain.toml` file. However, Nix tooling may prefer to use a Nix-defined components list instead of the one defined by `rust-toolchain.toml` (implicitly or not).

This PR unlocks a 3rd option: transforming the rustup channel spec into a fenix toolchain, so that Nix tooling that prefers not to reinvent the wheel but doesn't wish to be constrained by all of `rust-toolchain.toml`'s definitions may freely do so.

---

The motivating example: [devenv](https://github.com/cachix/devenv) uses a [Nix-defined `components` list](https://github.com/cachix/devenv/blob/9d51052c5983724a9225fa62587e0cbe51e50622/src/modules/languages/rust.nix#L7). This is necessary since eg [it's recommended that rust-analyzer not be included in a `rust-toolchain.toml` file](https://rust-lang.github.io/rustup/concepts/profiles.html)

> If you are looking for a way to install devtools such as `miri` or IDE integration tools (`rust-analyzer`), you should use the `default` profile and install the needed additional components manually, either by using `rustup component add` or by using `-c` when installing the toolchain.

This results in `devenv` and `rustup` being at-odds: rustup doesn't want you to bootstrap dev/integration tools in your workspace, but devenv wants to bootstrap as much as possible in the workspace.