### PR TITLE
Allow overriding the dist server

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,6 +201,7 @@ Some outputs are toolchains, a rust toolchain in fenix is structured like this:
   file | path to the rust toolchain file, usually either `./rust-toolchain` or `./rust-toolchain.toml`, conflicts with `dir`
   dir | path to the directory that has `rust-toolchain` or `rust-toolchain.toml`, conflicts with `file`
   sha256 | sha256 of the manifest, required in pure evaluation mode, set to `lib.fakeSha256` to get the actual sha256 from the error message
+  root | rustup server to download the toolchain from. Defaults to `https://static.rust-lang.org/dist`.
 
   ```nix
   fromToolchainFile {
@@ -546,6 +547,35 @@ x86_64-linux | x86_64-unknown-linux-gnu
     };
   }
   ```
+</details>
+
+<details>
+  <summary>Use a rustup mirror, such as pannamax, to download the components indicated in a rust toolchain file.</summary>
+
+  ```nix
+  {
+    inputs = {
+      fenix = {
+        url = "github:nix-community/fenix";
+        inputs.nixpkgs.follows = "nixpkgs";
+      };
+      nixpkgs.url = "nixpkgs/nixos-unstable";
+      rust-manifest = {
+        url = "https://static.rust-lang.org/dist/2022-02-06/channel-rust.toml";
+        flake = false;
+      };
+    };
+
+    outputs = { self, fenix, nixpkgs, rust-manifest }: {
+      packages.x86_64-linux.default = fromToolchainFile {
+        file = ./rust-toolchain.toml;
+        sha256 = lib.fakeSha256;
+        root = "https://127.0.0.1:5900/rustup/dist
+      };
+    };
+  }
+  ```
+
 </details>
 
 ## Contributing

--- a/default.nix
+++ b/default.nix
@@ -42,7 +42,7 @@ let
       toolchain = mkToolchain suffix {
         inherit (manifest) date;
         components = mapAttrs
-          (_: src: { url = builtins.replaceStrings [ default_dist_server ] [ root ] src.url; sha256 = src.hash; })
+          (_: src: { url = builtins.replaceStrings [ default_dist_server ] [ root ] src.xz_url; sha256 = src.xz_hash; })
           (filterAttrs (_: src: src ? available && src.available) (mapAttrs
             (_: pkg: pkg.target."*" or pkg.target.${target} or null)
             manifest.pkg));

--- a/default.nix
+++ b/default.nix
@@ -42,7 +42,14 @@ let
       toolchain = mkToolchain suffix {
         inherit (manifest) date;
         components = mapAttrs
-          (_: src: { url = builtins.replaceStrings [ default_dist_server ] [ root ] src.xz_url; sha256 = src.xz_hash; })
+          (_: src:
+            let
+              # Either use xz_url/xz_hash if xz_url is present, or url/hash
+              # otherwise.
+              url = if src ? xz_url then src.xz_url else src.url;
+              hash = if src ? xz_url then src.xz_hash else src.hash;
+            in
+            { url = builtins.replaceStrings [ default_dist_server ] [ root ] url; sha256 = hash; })
           (filterAttrs (_: src: src ? available && src.available) (mapAttrs
             (_: pkg: pkg.target."*" or pkg.target.${target} or null)
             manifest.pkg));

--- a/default.nix
+++ b/default.nix
@@ -84,7 +84,7 @@ let
           date = elemAt matches 3;
         })
       (match
-        "^(stable|beta|nightly|[[:digit:]]+\.[[:digit:]]+(\.[[:digit:]]+)?)(-([[:digit:]]{4}-[[:digit:]]{2}-[[:digit:]]{2}))?(-([-[:alnum:]]+))?\n?$"
+        "^(stable|beta|nightly|[[:digit:]]+\.[[:digit:]]+(\.[[:digit:]]+(-beta\.[[:digit:]]+)?)?)(-([[:digit:]]{4}-[[:digit:]]{2}-[[:digit:]]{2}))?(-([-[:alnum:]]+))?\n?$"
         name);
 
   fromToolchainFile' = target:


### PR DESCRIPTION
The goal of this PR is to make it possible to use a mirror of rustup, such as one created using [Panamax](https://github.com/panamax-rs/panamax), with fenix.

To do so, it fixes three issues:

- When setting a custom dist server, if the manifest contains links to the default dist server, rustup will automatically replace it with an URL pointing to the custom dist server. This allows making very naive mirrors of the rustup dist server without having to modify the channel manifests.
   Currently, fenix allows setting a custom dist server through `toolchainOf`, but it does not replicate this behavior of overriding the URL in the manifests. This PR adds this behavior.

- Furthermore, it adds a `root` argument to `fromToolchainFile`, allowing the simultaneous use of a toolchain file and a custom dist server.

- Finally, it replaces the archive it gets from the `gz` ones to `xz` ones. Rust started providing `xz` archives in may 2017, and rustup switched to grabbing the `xz` archives not long after. Panamax, the most popular tool to mirror `rustup`, defaults to only grabbing the `xz` archives.