### PR TITLE
Add `fromToolchainName` to targets

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -154,6 +154,7 @@ nightlyToolchains.${v} // rec {
           fromManifestFile = fromManifestFile' target "";
           toolchainOf = toolchainOf' target;
           fromToolchainFile = fromToolchainFile' target;
+          fromToolchainName = { name, sha256 ? "" }: fromToolchainName' target name sha256;
         })
       collectedTargets;
 


### PR DESCRIPTION
This would allow combining components from a specific version in a cross compilation context:

```nix
let
  name = (pkgs.lib.importTOML file).toolchain.channel;
  fenixPackage = fenix.packages.${buildPlatform};
  toolchain = fenixPackage.fromToolchainName { inherit name sha256; };
  targetToolchain = fenixPackage.targets.${targetPlatform}.fromToolchainName { inherit name sha256; };
in
fenixPackage.combine [
  toolchain.rustc
  toolchain.cargo
  targetToolchain.rust-std
];
```