### PR TITLE
Add `rustc` libraries to `rust-analyzer`

### DIFF
--- a/lib/mk-toolchain.nix
+++ b/lib/mk-toolchain.nix
@@ -108,6 +108,17 @@ let
                 -add_rpath ${toolchain.rustc}/lib $out/bin/rustfmt || true
             ''}
           ''}
+
+          ${optionalString (component == "rust-analyzer-preview") ''
+            ${optionalString stdenv.isLinux ''
+              patchelf \
+                --set-rpath ${toolchain.rustc}/lib $out/bin/rust-analyzer || true
+            ''}
+            ${optionalString stdenv.isDarwin ''
+              install_name_tool \
+                -add_rpath ${toolchain.rustc}/lib $out/bin/rust-analyzer || true
+            ''}
+          ''}
         '';
         dontStrip = true;
         meta = {


### PR DESCRIPTION
Adds the `rustc` libraries to the runtime path of `rust-analyzer`.

Tested on:
```shell
➜ uname -a
Linux nixos 6.8.4 #1-NixOS SMP Thu Apr  4 18:25:06 UTC 2024 aarch64 GNU/Linux
```

#### Repro

```console
nix shell -f . stable.rust-analyzer
rust-analyzer --version
```

#### Expected
```
rust-analyzer 1.77.2 (25ef9e3d 2024-04-09)
```

#### Actual 
```
rust-analyzer: error while loading shared libraries: librustc_driver-4766cc27bbc2a07e.so: cannot open shared object file: No such file or directory
```