### PR TITLE
fix jq assignment

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -182,7 +182,7 @@ nightlyToolchains.${v} // rec {
   rust-analyzer-vscode-extension =
     let
       setDefault = k: v: ''
-        .contributes.configuration.properties."rust-analyzer.${k}".default = "${v}"
+        .contributes.configuration |= map(.properties."rust-analyzer.${k}".default = "${v}")
       '';
     in
     pkgs.vscode-utils.buildVscodeExtension {


### PR DESCRIPTION
CI Error:

```
error: builder for '/nix/store/9bsqma1df0mcyhrmvxhjcixs82da77h4-vscode-extension-rust-analyzer-53be113.drv' failed with exit code 5;
       last 7 log lines:
       > Running phase: unpackPhase
       > unpacking source archive /nix/store/mj54v0yxq880rczhh1fzv79ws1dg20ga-rust-analyzer-vsix.zip
       > source root is extension
       > setting SOURCE_DATE_EPOCH to timestamp 1718670294 of file extension/out/main.js
       > Running phase: patchPhase
       > jq: error (at package.json:3157): Cannot index array with string "properties"
       > /nix/store/ashgigyp2dkvfi1spyl9nsnirvbk67vh-stdenv-darwin/setup: line 140: pop_var_context: head of shell_variables not a function context
       For full logs, run 'nix log /nix/store/9bsqma1df0mcyhrmvxhjcixs82da77h4-vscode-extension-rust-analyzer-53be113.drv'.
```

It seems like rust analyzers `package.json` format has changed. I think this happened in https://github.com/rust-lang/rust-analyzer/commit/bf1a3a32bdd018b7d44696bafe40a7ff0538eda0. The configuration field is an array instead of an object now which broke some of our `jq` code. This PR should resolve this