### PR TITLE
docs: update "building with crane" example in `README.md`

### DIFF
--- a/README.md
+++ b/README.md
@@ -446,10 +446,6 @@ x86_64-linux | x86_64-unknown-linux-gnu
     inputs = {
       crane = {
         url = "github:ipetkov/crane";
-        inputs = {
-          flake-utils.follows = "flake-utils";
-          nixpkgs.follows = "nixpkgs";
-        };
       };
       fenix = {
         url = "github:nix-community/fenix";
@@ -463,7 +459,8 @@ x86_64-linux | x86_64-unknown-linux-gnu
       flake-utils.lib.eachDefaultSystem (system: {
         packages.default =
           let
-            craneLib = crane.lib.${system}.overrideToolchain
+            pkgs = nixpkgs.legacyPackages.${system};
+            craneLib = (crane.mkLib pkgs).overrideToolchain
               fenix.packages.${system}.minimal.toolchain;
           in
 


### PR DESCRIPTION
Since crane [v0.19.0](https://github.com/ipetkov/crane/releases/tag/v0.19.0), (https://github.com/ipetkov/crane/commit/6f7504ad93304e8ddf29c0b82442f61c03900ccb), the `crane.lib` no longer exists, but still mentioned in `readme.md`.
https://github.com/nix-community/fenix/blob/fa3610f841725c8e20fc0fab070ee60609fdd5ee/README.md?plain=1#L466

```
$ nix eval
warning: input 'crane' has an override for a non-existent input 'flake-utils'
warning: input 'crane' has an override for a non-existent input 'nixpkgs'
error: attribute 'lib' missing
       at /nix/store/bqx681q21lm8ynqbd5r0jc69y03dxgfh-source/flake.nix:22:24:
           21|           let
           22|             craneLib = crane.lib.${system}.overrideToolchain
             |                        ^
           23|               fenix.packages.${system}.minimal.toolchain;
```
