### PR TITLE
don't take a `system` argument in `default.nix`

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,6 +1,6 @@
 let
   inherit (builtins)
-    currentSystem elemAt filter fromJSON mapAttrs match readFile substring;
+    elemAt filter fromJSON mapAttrs match readFile substring;
 
   getFlake = name:
     with (fromJSON (readFile ./flake.lock)).nodes.${name}.locked; {
@@ -12,8 +12,7 @@ let
     };
 in
 
-{ system ? currentSystem
-, pkgs ? import (getFlake "nixpkgs") { localSystem = { inherit system; }; }
+{ pkgs ? import (getFlake "nixpkgs") { }
 , lib ? pkgs.lib
 , rust-analyzer-src ? getFlake "rust-analyzer-src"
 , rust-analyzer-rev ? substring 0 7 (rust-analyzer-src.rev or "0000000")

--- a/flake.nix
+++ b/flake.nix
@@ -75,7 +75,7 @@
             }
           else v)
         (import ./. {
-          inherit system rust-analyzer-src;
+          inherit rust-analyzer-src;
           inherit (nixpkgs) lib;
           pkgs = nixpkgs.legacyPackages.${system};
         }));


### PR DESCRIPTION
Just one `system` is insufficient for cross compilation, although I'm not sure cross compilation is a concern for fenix.

Either way, nixpkgs' default behavior is good enough, and if callers need to do special things about systems, they can do so by providing an instance of nixpkgs configured the way they need it to be.

Also, I did some archeology and didn't find any specific rationale for the original choices:

* https://github.com/nix-community/fenix/pull/28/commits/c6eba37e469ed12c12eff8850831cb5784c385b9
* https://github.com/nix-community/fenix/commit/3d98d48fe91763dfc380f635da9c13de449dd509