### PR TITLE
fix(rust-analyzer): use `pname` in call to `buildVscodeExtension`

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -188,7 +188,7 @@ nightlyToolchains.${v} // rec {
       '';
     in
     pkgs.vscode-utils.buildVscodeExtension {
-      name = "rust-analyzer-${rust-analyzer-rev}";
+      pname = "rust-analyzer-${rust-analyzer-rev}";
       version = rust-analyzer-rev;
       src = ./data/rust-analyzer-vsix.zip;
       vscodeExtName = "rust-analyzer";


### PR DESCRIPTION
Thanks for all your hard work on Fenix.

rust-analyzer builds broke for me shortly after nixos/nixpkgs#354740 was merged.

```bash
 … from call site
         at /nix/store/bd5j75vv19g3q0ijgi4plvfwsb95648d-source/default.nix:190:5:
          189|     in
          190|     pkgs.vscode-utils.buildVscodeExtension {
             |     ^
          191|       name = "rust-analyzer-${rust-analyzer-rev}";

       error: function 'buildVscodeExtension' called without required argument 'pname'
       at /nix/store/sp3c1kqpv8lnzi9njdly8ig00gg9c3p8-source/pkgs/applications/editors/vscode/extensions/vscode-utils.nix:13:5:
           12|   buildVscodeExtension =
           13|     a@{
             |     ^
           14|       pname,
```

This PR works for me locally by passing `pname` instead of `name`. Please let me know if anything else needs to be done. 

```bash
 - system: `"aarch64-darwin"`
 - host os: `Darwin 24.1.0, macOS 15.1.1`
 - multi-user?: `yes`
 - sandbox: `no`
 - version: `nix-env (Lix, like Nix) 2.91.1
```