### PR TITLE
fix: pass both name and pname to buildVscodeExtension

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -189,6 +189,7 @@ nightlyToolchains.${v} // rec {
     in
     pkgs.vscode-utils.buildVscodeExtension {
       name = "rust-analyzer-${rust-analyzer-rev}";
+      pname = "rust-analyzer";
       version = rust-analyzer-rev;
       src = ./data/rust-analyzer-vsix.zip;
       vscodeExtName = "rust-analyzer";


### PR DESCRIPTION
Supersedes #180 and #182 

Sorry for creating a third PR on this, however I really would like this issue to be solved as quickly as possible as it is currently blocking stable 1.83.0 from being merged into main.

As suggested in https://github.com/nix-community/fenix/pull/180#issuecomment-2508048525 we could also try to detect which argument the function expects and pass the correct one, but I think just passing both arguments should be the simplest solution. Please let me know if there are any disadvantages to this approach.