### PR TITLE
Pass `pname` to `buildVscodeExtension`, instead of `name`

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -188,7 +188,7 @@ nightlyToolchains.${v} // rec {
       '';
     in
     pkgs.vscode-utils.buildVscodeExtension {
-      name = "rust-analyzer-${rust-analyzer-rev}";
+      pname = "rust-analyzer-${rust-analyzer-rev}";
       version = rust-analyzer-rev;
       src = ./data/rust-analyzer-vsix.zip;
       vscodeExtName = "rust-analyzer";


### PR DESCRIPTION
With latest nixpkgs, evaluation fails with the following
```
       error: function 'buildVscodeExtension' called without required argument 'pname'
       at /nix/store/7c2g8d7nzs52snmcf5fk5m4nwvnbkqqm-source/pkgs/applications/editors/vscode/extensions/vscode-utils.nix:13:5:
           12|   buildVscodeExtension =
           13|     a@{
             |     ^
           14|       pname,
```

The solution is to pass `pname` to `buildVscodeExtension`, instead of `name`