### PR TITLE
fromToolchainFile : Fix vscode-utils.buildVscodeExtension

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -188,6 +188,7 @@ nightlyToolchains.${v} // rec {
       '';
     in
     pkgs.vscode-utils.buildVscodeExtension {
+      pname = "rust-analyzer";
       name = "rust-analyzer-${rust-analyzer-rev}";
       version = rust-analyzer-rev;
       src = ./data/rust-analyzer-vsix.zip;


### PR DESCRIPTION
nixpkgs expects that buildVscodeExtension has `pname`, but this package uses `name`.
Then it throws an error like https://github.com/NixOS/nixpkgs/pull/282798#issuecomment-2533222218 .

fenix uses name for buildVscodeExtension.
https://github.com/nix-community/fenix/blob/main/default.nix#L191

nixpkgs uses pname for buildVscodeExtension.
https://github.com/NixOS/nixpkgs/blob/staging/pkgs/applications/editors/vscode/extensions/rust-lang.rust-analyzer/default.nix#L75

