### PR TITLE
Don't trigger toRustTarget deprecation warning

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -122,7 +122,10 @@ let
       manifest.pkg.rust-std.target;
 in
 
-nightlyToolchains.${v} // rec {
+(lib.removeAttrs nightlyToolchains.${v} [ "toRustTarget" ]) // rec {
+  # TODO: drop toRustTarget workaround to not print the deprecation warning
+  inherit (nightlyToolchains.${v}) toRustTarget;
+
   combine = combine' "rust-mixed";
 
   fromManifest = fromManifest' v "";


### PR DESCRIPTION
Merging attrs with `//` triggers lib.warn. I try to work around this by removing the attr and then adding it back, so it is not being evaluated.