### PR TITLE
fix(darwin): remove legacy Apple SDK frameworks

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -167,7 +167,6 @@ nightlyToolchains.${v} // rec {
     cargoBuildFlags = [ "-p" "rust-analyzer" ];
     buildInputs = with pkgs;
       optionals stdenv.isDarwin [
-        darwin.apple_sdk.frameworks.CoreServices
         libiconv
       ];
     doCheck = false;


### PR DESCRIPTION
Thanks to the new maintainers for the time you're putting into this.

The warning mentioned in #201 is now a hard error. The [linked docs](https://nixos.org/manual/nixpkgs/stable/#sec-darwin-legacy-frameworks) suggest simply removing the SDK, which fixes the build on aarch64-darwin.

As an aside, is there interest in a PR to switch this repo to `nixfmt-rfc-style`? I had to disable it to avoid a large diff.