### PR TITLE
fix(rust-analyzer-vscode-extension): Add `unzip` to `nativeBuildInputs`

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -218,7 +218,7 @@ nightlyToolchains.${v} // rec {
       vscodeExtName = "rust-analyzer";
       vscodeExtPublisher = "The Rust Programming Language";
       vscodeExtUniqueId = "rust-lang.rust-analyzer";
-      nativeBuildInputs = with pkgs; [ jq moreutils ];
+      nativeBuildInputs = with pkgs; [ jq moreutils unzip ];
       postPatch = ''
         jq -e '
           ${setDefault "server.path" "${rust-analyzer}/bin/rust-analyzer"}


### PR DESCRIPTION
Closes #225

Adds `unzip` to rust-analyzer-vscode-extension `nativeBuildInputs` to fix the unpacking issue.