### PR TITLE
Fix useless \ escapes in regex

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -91,7 +91,7 @@ let
           date = elemAt matches 3;
         })
       (match
-        "^(stable|beta|nightly|[[:digit:]]+\.[[:digit:]]+(\.[[:digit:]]+)?)(-([[:digit:]]{4}-[[:digit:]]{2}-[[:digit:]]{2}))?(-([-[:alnum:]]+))?\n?$"
+        "^(stable|beta|nightly|[[:digit:]]+\\.[[:digit:]]+(\\.[[:digit:]]+)?)(-([[:digit:]]{4}-[[:digit:]]{2}-[[:digit:]]{2}))?(-([-[:alnum:]]+))?\n?$"
         name);
 
   fromToolchainFile' = target:


### PR DESCRIPTION
These need to be \\, so the dot is interpreted literally.