### PR TITLE
fix: libatomic should be in rpath

### DIFF
--- a/lib/combine.nix
+++ b/lib/combine.nix
@@ -18,7 +18,7 @@ symlinkJoin {
 
       ${optionalString stdenv.isLinux ''
         if isELF "$file"; then
-          patchelf --set-rpath $out/lib "$file" || true
+          patchelf --set-rpath $out/lib:${stdenv.cc.cc.lib}/lib "$file" || true
         fi
       ''}
 

--- a/lib/mk-toolchain.nix
+++ b/lib/mk-toolchain.nix
@@ -10,7 +10,7 @@ let
     platforms removeSuffix;
 
   combine = callPackage ./combine.nix { };
-  rpath = "${zlib}/lib:$out/lib";
+  rpath = "${zlib}/lib:$out/lib:${stdenv.cc.cc.lib}/lib";
 
   toolchain = mapAttrs
     (component: source:
@@ -52,7 +52,7 @@ let
                 if isELF "$file"; then
                   patchelf \
                     --set-interpreter ${stdenv.cc.bintools.dynamicLinker} \
-                    --set-rpath ${stdenv.cc.cc.lib}/lib:${rpath} \
+                    --set-rpath ${rpath} \
                     "$file" || true
                 fi
               done


### PR DESCRIPTION
Using fenix on i686 fails with `cargo: error while loading shared libraries: libatomic.so.1: cannot open shared object file: No such file or directory`