### PR TITLE
update: iterate instead of recursing when walking back nightlies

### DIFF
--- a/update
+++ b/update
@@ -28,17 +28,20 @@ def write_json(channel: str, content: Any) -> None:
         file.write("\n")
 
 
-def fetch_nightly(d: Optional[datetime.date] = None) -> None:
-    date_path = f"/{d}" if d else ""
+def fetch_nightly() -> None:
+    fetch_date: Optional[datetime.date] = None
 
-    try:
-        resp = urlopen(f"{dist_root}{date_path}/channel-rust-nightly.toml")
-    except HTTPError as e:
-        if e.code == 404 and d:
-            fetch_nightly(d - one_day)
-        else:
+    while True:
+        date_path = f"/{fetch_date}" if fetch_date else ""
+
+        try:
+            resp = urlopen(f"{dist_root}{date_path}/channel-rust-nightly.toml")
+        except HTTPError as e:
+            if e.code == 404 and fetch_date:
+                fetch_date -= one_day
+                continue
             raise e
-    else:
+
         manifest = tomllib.load(resp)
         components = manifest["profiles"]
         date_str = manifest["date"]
@@ -47,7 +50,7 @@ def fetch_nightly(d: Optional[datetime.date] = None) -> None:
         skipped = False
 
         for target in targets:
-            if not d:
+            if not fetch_date:
                 nightly[target]["latest"] = {
                     "date": date_str,
                     "components": {},
@@ -113,8 +116,9 @@ def fetch_nightly(d: Optional[datetime.date] = None) -> None:
                         },
                     }
 
-        if skipped:
-            fetch_nightly(date - one_day)
+        if not skipped:
+            return
+        fetch_date = date - one_day
 
 
 fetch_nightly()

--- a/update
+++ b/update
@@ -88,9 +88,10 @@ def fetch_nightly() -> None:
                             "sha256": src["hash"],
                         }
                     # rustc-docs is only available on x86_64-unknown-linux-gnu
-                    # and it is causing complete toolchains to be a lot older
-                    # than they need to be
-                    elif component == "rustc-docs":
+                    # and rustc-codegen-cranelift-preview was never built for
+                    # i686-unknown-linux-gnu. they were causing complete
+                    # toolchains to be a lot older than they need to be
+                    elif component in ("rustc-docs", "rustc-codegen-cranelift-preview"):
                         continue
                     else:
                         skipped = True


### PR DESCRIPTION
The nightly update job has been failing with a `RecursionError` since 2026-07-02. The update script resolves each target's profiles by walking back one nightly at a time until every component is available, and that walk-back was implemented recursively. Since `rustc-codegen-cranelift-preview` entered the complete profile in October 2023 without ever being built for `i686-unknown-linux-gnu`, every run walked back to 2023-10-28 to resolve that target's complete profile, and on 2026-07-02 the walk (978 days) crossed python's default recursion limit.

This PR makes the walk-back iterative so it works at any depth, and additionally exempts `rustc-codegen-cranelift-preview` from the availability requirement, the same way `rustc-docs` already is. The exemption unpins the `i686` complete profile from `nightly-2023-10-28` (it now resolves on the current nightly, just without cranelift, which it never actually had) and drops the script's runtime from ~7 minutes of fetching roughly a thousand dated manifests to about a second.

Fixes https://github.com/nix-community/fenix/issues/248.