### PR TITLE
fix: symlink libLLVM.dylib into rustlib target lib dirs on darwin

### DIFF
--- a/lib/mk-toolchain.nix
+++ b/lib/mk-toolchain.nix
@@ -79,6 +79,19 @@ let
             ''}
           ''}
 
+          ${optionalString (component == "rustc") ''
+            ${optionalString stdenv.hostPlatform.isDarwin ''
+              if [ -e $out/lib/libLLVM.dylib ]; then
+                for dir in $out/lib/rustlib/*-apple-darwin; do
+                  if [ -d "$dir/bin" ] && [ ! -e "$dir/lib/libLLVM.dylib" ]; then
+                    mkdir -p "$dir/lib"
+                    ln -s $out/lib/libLLVM.dylib "$dir/lib/libLLVM.dylib"
+                  fi
+                done
+              fi
+            ''}
+          ''}
+
           ${optionalString (component == "cargo") ''
             ${optionalString stdenv.hostPlatform.isDarwin ''
               install_name_tool \


### PR DESCRIPTION
Since rust-lang/rust#157205 the darwin dist links rust-lld and rust-objcopy against libLLVM.dylib dynamically, with an rpath of @loader_path/../lib, i.e. lib/rustlib/<host>/lib. The rustc component only ships the dylib at lib/libLLVM.dylib and, unlike rustup, fenix sets no fallback library path, so these tools fail to load:

    dyld: Library not loaded: @rpath/libLLVM.dylib

Symlink the dylib into lib/rustlib/*-apple-darwin/lib so the baked-in rpath resolves.

Fixes #253